### PR TITLE
feat(ui): improve music detail immersion controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ CLAUDE.md
 UPSTREAM.md
 !README.md
 !changelog.md
+/.vs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BakaMusic
 
-[![Stars](https://badgen.net/github/stars/Zencok/BakaMusic)](https://github.com/ShenYichenCN/BakaMusic_syc/stargazers)
+[![Stars](https://badgen.net/github/stars/ShenYichenCN/BakaMusic_syc)](https://github.com/ShenYichenCN/BakaMusic_syc/stargazers)
 [![License](https://badgen.net/badge/license/AGPL-3.0-only/blue)](LICENSE)
 
 **无广告、无内置在线音源、由插件扩展。**

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # BakaMusic
 
-[![Stars](https://badgen.net/github/stars/Zencok/BakaMusic)](https://github.com/Zencok/BakaMusic/stargazers)
-[![Latest Release](https://badgen.net/github/release/Zencok/BakaMusic)](https://github.com/Zencok/BakaMusic/releases/latest)
-[![Downloads](https://badgen.net/github/assets-dl/Zencok/BakaMusic)](https://github.com/Zencok/BakaMusic/releases)
-[![Issues](https://badgen.net/github/issues/Zencok/BakaMusic)](https://github.com/Zencok/BakaMusic/issues)
+[![Stars](https://badgen.net/github/stars/Zencok/BakaMusic)](https://github.com/ShenYichenCN/BakaMusic_syc/stargazers)
 [![License](https://badgen.net/badge/license/AGPL-3.0-only/blue)](LICENSE)
 
 **无广告、无内置在线音源、由插件扩展。**
 
-BakaMusic 是基于 Electron、React 和 TypeScript 的跨平台桌面音乐播放器，提供播放、歌词、歌单、本地音乐、下载与主题框架；在线搜索与媒体来源由用户安装的插件提供。
-
+BakaMusic_syc 是基于 BakaMusic 修改，由Electron、React 和 TypeScript 的跨平台桌面音乐播放器，提供播放、歌词、歌单、本地音乐、下载与主题框架；在线搜索与媒体来源由用户安装的插件提供。
+原项目地址：[https://github.com/zencok/
+](https://github.com/Zencok/BakaMusic)
 ## 目录
 
 - [功能](#功能)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BakaMusic
+# BakaMusic_syc
 
 [![Stars](https://badgen.net/github/stars/ShenYichenCN/BakaMusic_syc)](https://github.com/ShenYichenCN/BakaMusic_syc/stargazers)
 [![License](https://badgen.net/badge/license/AGPL-3.0-only/blue)](LICENSE)

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -77,7 +77,7 @@ const config: ForgeConfig = {
             certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
             certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD,
             description: "BakaMusic",
-            website: "https://github.com/Zencok/BakaMusic",
+            website: "https://github.com/ShenYichenCN/BakaMusic_syc",
         } : undefined,
         osxSign: macSigningConfigured ? {
             identity: process.env.MACOS_SIGN_IDENTITY,
@@ -95,7 +95,7 @@ const config: ForgeConfig = {
             appId: "com.zencok.bakamusic",
             compression: "maximum",
             targets: ["nsis", "nsis-web"],
-            webPackageBaseUrl: "https://github.com/Zencok/BakaMusic/releases/download",
+            webPackageBaseUrl: "https://github.com/ShenYichenCN/BakaMusic_syc/releases/download",
             webPackageName: "bakamusic",
             webPackageUrlPrefix: nsisWebGithubAccelerator,
             win: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19324,6 +19324,7 @@
     },
     "node_modules/windows-notification-state": {
       "version": "2.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bakamusic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bakamusic",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@applemusic-like-lyrics/lyric": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bakamusic",
   "productName": "BakaMusic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "一个插件化、定制化、无广告的免费音乐播放器。",
   "main": ".webpack/main",
   "engines": {

--- a/src/assets/icons/arrows-pointing-in.svg
+++ b/src/assets/icons/arrows-pointing-in.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75v3.75A1.5 1.5 0 0 1 7.5 9H3.75M9 9 3.75 3.75M15 3.75v3.75A1.5 1.5 0 0 0 16.5 9h3.75M15 9l5.25-5.25M9 20.25V16.5A1.5 1.5 0 0 0 7.5 15H3.75M9 15l-5.25 5.25M15 20.25V16.5a1.5 1.5 0 0 1 1.5-1.5h3.75M15 15l5.25 5.25" />
+</svg>

--- a/src/assets/icons/arrows-pointing-out.svg
+++ b/src/assets/icons/arrows-pointing-out.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9V5.25A1.5 1.5 0 0 1 5.25 3.75H9M3.75 5.25 9 10.5M15 3.75h3.75a1.5 1.5 0 0 1 1.5 1.5V9M15 10.5l5.25-5.25M9 20.25H5.25a1.5 1.5 0 0 1-1.5-1.5V15M9 13.5l-5.25 5.25M20.25 15v3.75a1.5 1.5 0 0 1-1.5 1.5H15M15 13.5l5.25 5.25" />
+</svg>

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -264,14 +264,14 @@ export const themePackStoreBaseUrl = [
 ];
 
 const appLatestReleaseApiUrl =
-    "https://api.github.com/repos/Zencok/BakaMusic/releases/latest";
+    "https://api.github.com/repos/ShenYichenCN/BakaMusic_syc/releases/latest";
 const appLatestReleasePageUrl =
-    "https://github.com/Zencok/BakaMusic/releases/latest";
+    "https://github.com/ShenYichenCN/BakaMusic_syc/releases/latest";
 
 // GitHub API 端点：与主题商店一致，优先并行尝试加速前缀。
 export const appUpdateApiSources = [
     ...githubAcceleratorPrefixes.map((prefix) => `${prefix}${appLatestReleaseApiUrl}`),
-    "https://api.gitmirror.com/repos/Zencok/BakaMusic/releases/latest",
+    "https://api.gitmirror.com/repos/ShenYichenCN/BakaMusic_syc/releases/latest",
     appLatestReleaseApiUrl,
 ];
 

--- a/src/renderer/components/Header/index.scss
+++ b/src/renderer/components/Header/index.scss
@@ -60,7 +60,7 @@
     }
 
     & .header-search {
-      -webkit-app-region: none;
+      -webkit-app-region: no-drag;
       position: relative;
       min-width: 260px;
       width: min(360px, 34vw);
@@ -147,7 +147,7 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    -webkit-app-region: none;
+    -webkit-app-region: drag;
     gap: 6px;
     padding-left: 12px;
 
@@ -157,6 +157,7 @@
       opacity: 1;
       margin: 0 4px;
       background-color: var(--headerDividerColor, color-mix(in srgb, var(--textColor) 18%, transparent));
+      -webkit-app-region: no-drag;
     }
 
     & .sparkles-icon:hover {
@@ -164,6 +165,7 @@
     }
 
     & .header-button {
+      -webkit-app-region: no-drag;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/renderer/components/Modal/templates/Update/index.tsx
+++ b/src/renderer/components/Modal/templates/Update/index.tsx
@@ -45,7 +45,7 @@ export default function Update(props: IUpdateProps) {
 
     async function handleDownload() {
         if (!update?.download?.length) {
-            shellUtil.openExternal("https://github.com/Zencok/BakaMusic/releases/latest");
+            shellUtil.openExternal("https://github.com/ShenYichenCN/BakaMusic_syc/releases/latest");
             return;
         }
 
@@ -230,7 +230,7 @@ export default function Update(props: IUpdateProps) {
                                 data-type="normalButton"
                                 onClick={() => {
                                     shellUtil.openExternal(
-                                        "https://github.com/Zencok/BakaMusic/releases/latest",
+                                        "https://github.com/ShenYichenCN/BakaMusic_syc/releases/latest",
                                     );
                                 }}
                             >

--- a/src/renderer/components/MusicBar/widgets/MusicInfo/index.scss
+++ b/src/renderer/components/MusicBar/widgets/MusicInfo/index.scss
@@ -142,7 +142,8 @@
   }
 
   & .progress {
-    font-size: 0.74rem;
+    min-width: 82px;
+    font-size: 0.95rem;
     line-height: 1;
     color: var(--musicBarTextSecondary);
     letter-spacing: 0.01em;

--- a/src/renderer/components/MusicBar/widgets/Slider/index.scss
+++ b/src/renderer/components/MusicBar/widgets/Slider/index.scss
@@ -95,8 +95,9 @@ html[data-ui-style="glass"] .music-bar--slider-container {
   & .timeline-time {
     display: flex;
     align-items: center;
-    height: 20px;
-    font-size: 0.72rem;
+    min-width: 88px;
+    height: 22px;
+    font-size: 0.95rem;
     font-weight: 650;
     line-height: 1;
     letter-spacing: 0.025em;

--- a/src/renderer/components/MusicDetail/index.scss
+++ b/src/renderer/components/MusicDetail/index.scss
@@ -1,4 +1,4 @@
-﻿.music-detail--container {
+.music-detail--container {
     position: absolute;
     inset: 0;
     z-index: 3000;
@@ -29,24 +29,28 @@
         -webkit-app-region: no-drag;
     }
 
-    // True OS fullscreen (F11): hide chrome for a pure stage.
+    // True OS fullscreen (F11): fade chrome out for a pure stage.
     &[data-fullscreen="true"] {
         .music-detail-topbar {
-            display: none;
+            max-height: 0;
+            opacity: 0;
+            transform: translateY(-10px) scale(0.98);
+            pointer-events: none;
         }
 
         .music-detail-shell {
             padding: 36px 40px 40px;
-            gap: 28px;
+            gap: 0;
         }
 
         .music-detail-content {
             gap: clamp(28px, 3.4vw, 48px);
+            transform: scale(1);
         }
 
         .music-detail-primary-stage {
             width: min(100%, clamp(300px, 48vh, 500px));
-            transform: translateY(0);
+            transform: translateY(0) scale(1);
 
             &[data-cover-style="vinyl"] {
                 width: min(100%, clamp(320px, 50vh, 520px));
@@ -143,6 +147,14 @@
     .music-detail--container.music-detail--exit {
         animation-duration: 1ms;
     }
+
+    .music-detail-shell,
+    .music-detail-topbar,
+    .music-detail-content,
+    .music-detail-primary-stage,
+    .music-detail-lyric-column {
+        transition-duration: 1ms;
+    }
 }
 
 .music-detail-shell {
@@ -155,14 +167,24 @@
     display: flex;
     flex-direction: column;
     gap: 22px;
+    transition: padding 360ms cubic-bezier(0.16, 1, 0.3, 1), gap 360ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .music-detail-topbar {
+    max-height: 72px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 18px;
+    opacity: 1;
+    overflow: hidden;
+    transform: translateY(0) scale(1);
+    transform-origin: top center;
     -webkit-app-region: drag;
+    transition:
+        max-height 320ms cubic-bezier(0.16, 1, 0.3, 1),
+        opacity 220ms ease,
+        transform 320ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .music-detail-topbar-left,
@@ -175,15 +197,20 @@
 .music-detail-topbar-left {
     flex: 1;
     min-width: 0;
+    align-self: stretch;
+    -webkit-app-region: drag;
 }
 
 .music-detail-topbar-right {
+    align-self: stretch;
     flex-shrink: 0;
     -webkit-app-region: no-drag;
 }
 
 .music-detail-info-bar {
-    flex: 1;
+    flex: 0 1 auto;
+    -webkit-app-region: drag;
+    width: fit-content;
     min-width: 0;
     max-width: min(100%, 720px);
     display: flex;
@@ -191,9 +218,15 @@
     gap: 14px;
     padding: 10px 14px;
     border-radius: 22px;
+    overflow: hidden;
+    contain: paint;
     background: var(--musicDetailSurface);
-    border: 1px solid var(--musicDetailBorder);
-    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.14);
+    background-clip: padding-box;
+    border: 1px solid transparent;
+    box-shadow:
+        0 18px 44px rgba(0, 0, 0, 0.16),
+        inset 0 1px 0 rgba(255, 255, 255, 0.14);
+    -webkit-backdrop-filter: blur(18px) saturate(126%);
     backdrop-filter: blur(18px) saturate(126%);
 }
 
@@ -209,12 +242,13 @@
 .music-detail-info-copy {
     min-width: 0;
     display: flex;
-    flex: 1;
+    flex: 0 1 auto;
     flex-direction: column;
     gap: 6px;
 }
 
 .music-detail-info-title {
+    max-width: min(42vw, 540px);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -298,6 +332,11 @@
     grid-template-columns: minmax(320px, 440px) minmax(0, 1fr);
     gap: clamp(24px, 3vw, 38px);
     align-items: stretch;
+    transform: scale(0.992);
+    transform-origin: center;
+    transition:
+        gap 360ms cubic-bezier(0.16, 1, 0.3, 1),
+        transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .music-detail-primary-column {
@@ -320,11 +359,15 @@
     align-items: center;
     justify-content: center;
     margin: 0 auto;
-    transform: translateY(-16px);
+    transform: translateY(-16px) scale(0.98);
+    transform-origin: center;
     background: transparent !important;
     border: none !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
+    transition:
+        width 420ms cubic-bezier(0.16, 1, 0.3, 1),
+        transform 420ms cubic-bezier(0.16, 1, 0.3, 1);
 
     &[data-cover-style="vinyl"] {
         width: min(100%, clamp(280px, 45vh, 450px));
@@ -711,6 +754,7 @@
     display: flex;
     box-sizing: border-box;
     padding-bottom: 38px;
+    transition: padding-bottom 360ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @media screen and (max-width: 980px) {
@@ -755,7 +799,7 @@
     }
 
     .music-detail-primary-stage {
-        transform: translateY(-10px);
+        transform: translateY(-10px) scale(0.98);
     }
 
     .music-detail-info-bar {

--- a/src/renderer/components/MusicDetail/index.tsx
+++ b/src/renderer/components/MusicDetail/index.tsx
@@ -1,4 +1,4 @@
-﻿import AnimatedDiv from "../AnimatedDiv";
+import AnimatedDiv from "../AnimatedDiv";
 import "./index.scss";
 import albumImg from "@/assets/imgs/album-cover.jpg";
 import { PlayerState, qualityText } from "@/common/constant";
@@ -273,6 +273,11 @@ function MusicDetail() {
 
                     <div className="music-detail-topbar-right">
                         <RoundButton
+                            iconName="arrows-pointing-out"
+                            title="开启全屏沉浸模式"
+                            onClick={toggleImmersiveFullScreen}
+                        ></RoundButton>
+                        <RoundButton
                             iconName="minus"
                             title={t("app_header.minimize")}
                             onClick={() => {
@@ -347,6 +352,8 @@ function MusicDetail() {
                         <Lyric
                             active={musicDetailShown}
                             playerReady={lyricPlayerReady}
+                            isFullscreen={isFullscreen}
+                            onRequestFullscreen={toggleImmersiveFullScreen}
                         ></Lyric>
                     </div>
                 </div>

--- a/src/renderer/components/MusicDetail/widgets/Lyric/index.tsx
+++ b/src/renderer/components/MusicDetail/widgets/Lyric/index.tsx
@@ -54,9 +54,16 @@ type MusicDetailVinylTonearmReach = "outer" | "inner";
 interface ILyricProps {
     active: boolean;
     playerReady: boolean;
+    isFullscreen: boolean;
+    onRequestFullscreen: () => void;
 }
 
-export default function Lyric({ active, playerReady }: ILyricProps) {
+export default function Lyric({
+    active,
+    playerReady,
+    isFullscreen,
+    onRequestFullscreen,
+}: ILyricProps) {
     const currentMusic = useCurrentMusic();
     const lyricContext = useLyric();
     const lyricParser = lyricContext?.parser;
@@ -155,6 +162,16 @@ export default function Lyric({ active, playerReady }: ILyricProps) {
                     >
                         <SvgAsset iconName="magnifying-glass"></SvgAsset>
                     </div>
+                    {isFullscreen ? (
+                        <div
+                            className="music-detail-lyric-toolbar-button"
+                            role="button"
+                            title="关闭全屏沉浸模式"
+                            onClick={onRequestFullscreen}
+                        >
+                            <SvgAsset iconName="arrows-pointing-in"></SvgAsset>
+                        </div>
+                    ) : null}
                     <CoverStyleSelector></CoverStyleSelector>
                 </div>
             </div>

--- a/src/renderer/components/SvgAsset/index.tsx
+++ b/src/renderer/components/SvgAsset/index.tsx
@@ -3,6 +3,8 @@ import { CSSProperties, memo } from "react";
 export type SvgAssetIconNames =
     | "album"
     | "app-mark"
+    | "arrows-pointing-in"
+    | "arrows-pointing-out"
     | "array-download-tray"
     | "arrow-left-end-on-rectangle"
     | "arrow-path"

--- a/src/renderer/document/fallback.tsx
+++ b/src/renderer/document/fallback.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import trackPlayer from "../core/track-player";
 import "./styles/fallback.scss";
 
-const GITHUB_ISSUES_URL = "https://github.com/Zencok/BakaMusic/issues";
+const GITHUB_ISSUES_URL = "https://github.com/ShenYichenCN/BakaMusic_syc/issues";
 
 function formatDiagnosticValue(value: unknown, emptyLabel: string) {
     if (value === null || value === undefined) {

--- a/src/renderer/document/styles/ui-style-flat.scss
+++ b/src/renderer/document/styles/ui-style-flat.scss
@@ -306,16 +306,16 @@
         border-right: 1px solid var(--sideBarBorder);
         box-shadow: none;
         backdrop-filter: none;
-        --sideBarTextPrimary: var(--appTextPrimary);
-        --sideBarTextSecondary: color-mix(in srgb, var(--textColor) 70%, transparent);
-        --sideBarTextMuted: color-mix(in srgb, var(--textColor) 48%, transparent);
+        --sideBarTextPrimary: var(--theme-sidebar-text);
+        --sideBarTextSecondary: var(--theme-sidebar-text-secondary);
+        --sideBarTextMuted: var(--theme-sidebar-text-muted);
         --sideBarItemHover: var(--sideBarItemHover);
         --sideBarItemSelected: var(--sideBarItemSelected);
         --sideBarAccentBar: var(--primaryColor);
         --sideBarAccentBarOpacity: 1;
 
         .side-bar-section-title {
-            height: 2.15rem;
+            height: 2.32rem;
             padding: 0 0.56rem 0 0.68rem;
             border: 0;
             border-radius: 0;
@@ -331,14 +331,14 @@
         }
 
         .side-bar-section-chevron {
-            width: 1rem;
-            height: 1rem;
+            width: 1.4rem;
+            height: 1.4rem;
             background: transparent;
             color: var(--sideBarTextMuted);
 
             svg {
-                width: 0.66rem;
-                height: 0.66rem;
+                width: 0.9rem;
+                height: 0.9rem;
             }
         }
 
@@ -349,7 +349,7 @@
 
         .side-bar-section-text {
             color: currentColor;
-            font-size: 0.72rem;
+            font-size: 0.94rem;
             font-weight: 720;
             letter-spacing: 0.05em;
             text-transform: uppercase;
@@ -362,13 +362,19 @@
     }
 
     .side-bar--list-item-container {
-        height: 2.68rem;
-        font-size: 0.92rem;
+        $height: 2.82rem;
+        height: $height;
+        font-size: 1.02rem;
         border-radius: 6px;
         border: 0;
         gap: 0.62rem;
         padding: 0 0.72rem 0 0.82rem;
         font-weight: 600;
+
+        & svg {
+            width: 1.36rem;
+            height: 1.36rem;
+        }
 
         & span {
             font-weight: 600;
@@ -391,9 +397,14 @@
     }
 
     .side-bar-sheet-list .side-bar--list-item-container {
-        height: 2.42rem;
+        height: 2.58rem;
         padding-left: 1.05rem;
-        font-size: 0.87rem;
+        font-size: 0.98rem;
+
+        & svg {
+            width: 1.18rem;
+            height: 1.18rem;
+        }
     }
 }
 

--- a/src/renderer/pages/main-page/components/SideBar/index.scss
+++ b/src/renderer/pages/main-page/components/SideBar/index.scss
@@ -73,19 +73,19 @@
   gap: 0.04rem;
 
   & .side-bar--list-item-container {
-    height: 2.42rem;
+    height: 2.58rem;
     padding-left: 1.05rem;
-    font-size: 0.87rem;
+    font-size: 0.98rem;
   }
 
   & .side-bar--list-item-container svg {
-    width: 1.05rem;
-    height: 1.05rem;
+    width: 1.18rem;
+    height: 1.18rem;
   }
 }
 
 .side-bar-section-title {
-  height: 2.18rem;
+  height: 2.32rem;
   display: flex;
   align-items: center;
   padding: 0 0.5rem 0 0.44rem;
@@ -118,8 +118,8 @@
 }
 
 .side-bar-section-chevron {
-  width: 1.26rem;
-  height: 1.26rem;
+  width: 1.4rem;
+  height: 1.4rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -133,8 +133,8 @@
     background-color 160ms ease;
 
   & svg {
-    width: 0.78rem;
-    height: 0.78rem;
+    width: 0.9rem;
+    height: 0.9rem;
   }
 }
 
@@ -147,7 +147,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--sideBarTextSecondary, var(--appTextPrimary));
-  font-size: 0.84rem;
+  font-size: 0.94rem;
   font-weight: 620;
   letter-spacing: 0;
   line-height: 1;
@@ -167,12 +167,12 @@
 }
 
 .side-bar-navigation-action {
-  width: 1.55rem;
-  height: 1.55rem;
+  width: 1.72rem;
+  height: 1.72rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 1.55rem;
+  flex: 0 0 1.72rem;
   padding: 0;
   border: 0;
   border-radius: var(--iconButtonRadius, 50%);
@@ -185,8 +185,8 @@
     background-color 160ms ease;
 
   & svg {
-    width: 0.9rem;
-    height: 0.9rem;
+    width: 1.02rem;
+    height: 1.02rem;
   }
 
   &:hover,

--- a/src/renderer/pages/main-page/components/SideBar/widgets/ListItem/index.scss
+++ b/src/renderer/pages/main-page/components/SideBar/widgets/ListItem/index.scss
@@ -1,7 +1,7 @@
 .side-bar--list-item-container {
-  $height: 2.68rem;
+  $height: 2.82rem;
   height: $height;
-  font-size: 0.92rem;
+  font-size: 1.02rem;
   width: 100%;
   position: relative;
   display: flex;
@@ -21,8 +21,8 @@
     transform 160ms ease;
 
   & svg {
-    width: 1.22rem;
-    height: 1.22rem;
+    width: 1.36rem;
+    height: 1.36rem;
     flex-shrink: 0;
     opacity: 0.76;
     transition: opacity 160ms ease;

--- a/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.scss
+++ b/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.scss
@@ -1,7 +1,7 @@
 .side-bar-container--my-sheets {
   & .title {
     & .option-btn {
-      $size: 22px;
+      $size: 26px;
       width: $size;
       height: $size;
       border-radius: 6px;
@@ -23,8 +23,8 @@
       }
 
       & svg {
-        width: 13px;
-        height: 13px;
+        width: 15px;
+        height: 15px;
       }
     }
   }

--- a/src/renderer/pages/main-page/views/setting-view/routers/About/index.scss
+++ b/src/renderer/pages/main-page/views/setting-view/routers/About/index.scss
@@ -21,6 +21,8 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    gap: 0.85rem;
+    flex-wrap: wrap;
   }
 
   & .about-link-chip {
@@ -41,7 +43,7 @@
       );
     box-shadow: var(--settingControlInset);
     text-decoration: none;
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     font-weight: 680;
     line-height: 1;
     box-sizing: border-box;

--- a/src/renderer/pages/main-page/views/setting-view/routers/About/index.tsx
+++ b/src/renderer/pages/main-page/views/setting-view/routers/About/index.tsx
@@ -89,13 +89,19 @@ export default function About() {
                 <AboutInfoRow label={t("settings.about.current_project")}>
                     <AboutLink
                         iconName="logo"
-                        href="https://github.com/Zencok/BakaMusic"
+                        href="https://github.com/ShenYichenCN/BakaMusic_syc"
                     >
-                        BakaMusic@Zencok
+                        BakaMusic_syc@ShenYichenCN
                     </AboutLink>
                 </AboutInfoRow>
 
                 <AboutInfoRow label={t("settings.about.reference_project")}>
+                    <AboutLink
+                        iconName="logo"
+                        href="https://github.com/Zencok/BakaMusic"
+                    >
+                        BakaMusic@Zencok
+                    </AboutLink>
                     <AboutLink
                         iconName="code-bracket-square"
                         href="https://github.com/maotoumao/MusicFreeDesktop"

--- a/src/shared/native-playback/utility/native-playback-host.ts
+++ b/src/shared/native-playback/utility/native-playback-host.ts
@@ -506,10 +506,15 @@ function handleCommand(command: NativePlaybackRuntimeCommand) {
         case "seek":
             applySeek(command.seconds);
             break;
-        case "volume":
-            setProperty("volume", String(command.volume * 100));
+        case "volume": {
+            const ratio = Math.max(0, Math.min(1, command.volume));
+            // mpv 内核默认使用 3次方 物理衰减，会导致低百分比 (0~20%) 物理能量被严重压缩。
+            // 用开方函数补偿送到 mpv 的数值，使 UI 的 0%~100% 对应人耳听到的均匀音量。
+            const mpvVolume = ratio <= 0 ? 0 : Math.sqrt(ratio) * 100;
+            setProperty("volume", String(mpvVolume));
             volume = command.volume;
             break;
+        }
         case "speed":
             setProperty("speed", String(command.speed));
             playbackSpeed = command.speed;

--- a/src/shared/utils/main.ts
+++ b/src/shared/utils/main.ts
@@ -1253,7 +1253,7 @@ function createCanonicalReleaseAsset(tag: string, name: string): IGitHubReleaseA
         // URL from the validated tag and asset file name.
         browser_download_url: new URL(
             `${encodeURIComponent(tag)}/${encodeURIComponent(name)}`,
-            "https://github.com/Zencok/BakaMusic/releases/download/",
+            "https://github.com/ShenYichenCN/BakaMusic_syc/releases/download/",
         ).toString(),
     };
 }
@@ -1267,7 +1267,7 @@ function createReleaseFromLatestRedirect(location: unknown): IGitHubRelease {
         throw new Error("Latest release redirect is invalid");
     }
     const tagMatch = decodedLocation.match(
-        /\/Zencok\/BakaMusic\/releases\/tag\/(v?\d+\.\d+\.\d+(?:[.-][0-9A-Za-z.-]+)?)(?:[/?#]|$)/,
+        /\/ShenYichenCN\/BakaMusic_syc\/releases\/tag\/(v?\d+\.\d+\.\d+(?:[.-][0-9A-Za-z.-]+)?)(?:[/?#]|$)/,
     );
     if (!tagMatch) {
         throw new Error("Latest release redirect is invalid");

--- a/src/shared/utils/main.ts
+++ b/src/shared/utils/main.ts
@@ -29,6 +29,7 @@ import {
 const UPDATE_PROGRESS_INTERVAL_MS = 150;
 const UPDATE_DOWNLOAD_TIMEOUT_MS = 30_000;
 const MAX_RENDERER_FILE_BYTES = 64 * 1024 * 1024;
+const IMMERSIVE_MAXIMIZE_STAGING_MS = 900;
 type AppPathName = Parameters<typeof app.getPath>[0];
 type OpenDialogProperty = NonNullable<Electron.OpenDialogOptions["properties"]>[number];
 type SaveDialogProperty = NonNullable<Electron.SaveDialogOptions["properties"]>[number];
@@ -326,6 +327,54 @@ class Utils {
         }).__immersiveFullscreen = active;
     }
 
+    private waitForWindowAnimation(milliseconds: number): Promise<void> {
+        return new Promise((resolve) => {
+            setTimeout(resolve, milliseconds);
+        });
+    }
+
+    private waitForMainWindowMaximized(mainWindow: BrowserWindow): Promise<void> {
+        if (mainWindow.isMaximized()) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timeout);
+                mainWindow.off("maximize", finish);
+                resolve();
+            };
+            const timeout = setTimeout(finish, IMMERSIVE_MAXIMIZE_STAGING_MS);
+            mainWindow.once("maximize", finish);
+        });
+    }
+
+    private waitForMainWindowLeaveFullScreen(mainWindow: BrowserWindow): Promise<void> {
+        if (!mainWindow.isFullScreen()) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timeout);
+                mainWindow.off("leave-full-screen", finish);
+                resolve();
+            };
+            const timeout = setTimeout(finish, 700);
+            mainWindow.once("leave-full-screen", finish);
+        });
+    }
+
     private setImmersiveSessionEffects(active: boolean) {
         if (active) {
             this.windowManager.setAuxiliaryWindowsSuppressed(true);
@@ -347,7 +396,7 @@ class Utils {
         this.windowManager.setAuxiliaryWindowsSuppressed(false);
     }
 
-    private setImmersiveFullScreen(enabled: boolean): boolean {
+    private async setImmersiveFullScreen(enabled: boolean): Promise<boolean> {
         const mainWindow = this.getMainWindow();
         if (!mainWindow) {
             if (!enabled) {
@@ -364,12 +413,24 @@ class Utils {
 
             const wasMaximized = mainWindow.isMaximized();
             const bounds = mainWindow.getBounds();
-            // Native fullscreen from a maximized frameless window is unreliable on Windows.
-            if (wasMaximized) {
-                mainWindow.unmaximize();
+            // From a restored window, make the transition a true two-step sequence:
+            // 1) let the platform maximize animation complete;
+            // 2) only then switch the detail page into immersive fullscreen.
+            if (!wasMaximized) {
+                mainWindow.maximize();
+                await Promise.race([
+                    this.waitForMainWindowMaximized(mainWindow),
+                    this.waitForWindowAnimation(IMMERSIVE_MAXIMIZE_STAGING_MS),
+                ]);
+                if (mainWindow.isDestroyed()) {
+                    this.setImmersiveSessionEffects(false);
+                    return false;
+                }
             }
 
             // Prefer native fullscreen first (covers taskbar / exclusive mode).
+            // Do not unmaximize here: on Windows that visible restore step makes
+            // maximized -> immersive transitions twitch before fullscreen starts.
             try {
                 mainWindow.setFullScreenable(true);
                 mainWindow.setFullScreen(true);
@@ -413,22 +474,32 @@ class Utils {
 
         this.markImmersiveSession(mainWindow, false);
 
+        const restore = this.immersiveRestore;
+        this.immersiveRestore = null;
+
         if (mainWindow.isFullScreen()) {
             try {
                 mainWindow.setFullScreen(false);
+                await this.waitForMainWindowLeaveFullScreen(mainWindow);
             } catch {
                 // ignore
             }
         }
 
-        const restore = this.immersiveRestore;
-        this.immersiveRestore = null;
-
         if (restore) {
-            if (restore.usedBoundsFallback || !mainWindow.isFullScreen()) {
-                if (restore.wasMaximized) {
-                    mainWindow.maximize();
-                } else {
+            if (restore.wasMaximized) {
+                mainWindow.maximize();
+            } else {
+                // Same idea as pressing the maximize button while maximized: force
+                // the temporary staging maximize back to restored mode before applying
+                // the original small-window bounds. isMaximized() may already report
+                // false right after leaving native fullscreen, so do this unconditionally.
+                mainWindow.unmaximize();
+                await this.waitForWindowAnimation(120);
+                mainWindow.setBounds(restore.bounds);
+                await this.waitForWindowAnimation(180);
+                if (!mainWindow.isDestroyed()) {
+                    mainWindow.unmaximize();
                     mainWindow.setBounds(restore.bounds);
                 }
             }
@@ -439,7 +510,7 @@ class Utils {
         return false;
     }
 
-    private toggleImmersiveFullScreen(): boolean {
+    private async toggleImmersiveFullScreen(): Promise<boolean> {
         const mainWindow = this.getMainWindow();
         if (!mainWindow) {
             return false;


### PR DESCRIPTION
1.在歌曲详情页加入了开启/关闭沉浸模式按钮
2.为开启/关闭沉浸模式加入了过渡动画
3.更改了顶部栏可操纵范围，允许用户通过鼠标双击/拖拽改变窗口形态
4.为歌曲详情页左上角的音乐信息栏的模块长度进行了动态优化，允许根据歌曲信息实际长度调整模块的大小而非固定长短
5.优化了播放进度时间及主页侧边栏的文本大小